### PR TITLE
Add a python 3.7 image.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
-tags="3.4.9-stretch 3.5.6-stretch 3.6.7-stretch 2.7.16-stretch"
+#tags="3.4.9-stretch 3.5.6-stretch 3.6.7-stretch 3.7.3-stretch 2.7.16-stretch"
+tags="3.7.3-stretch"
 #tags="2.7.16-stretch"
-#gdals="2.3.1 2.3.2" 
-gdals="2.3.2" 
+#gdals="2.3.1 2.3.2"
+gdals="2.3.2"
 
 set -ex
 


### PR DESCRIPTION
I commented out the list of tags and added one for 3.7. The patch versions we have specified are no longer available on docker hub (only the latest patch version for a Major.Minor build is available) and I didn't want to update our images without testing.
For available images see:
https://hub.docker.com/_/python