### PR TITLE
Use multiple stages so the final image doesn't include build deps.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,19 @@
-ARG PYTHON_DOCKER_TAG=3.5-jessie
-FROM python:$PYTHON_DOCKER_TAG
+ARG PYTHON_DOCKER_TAG=3.7.3-stretch
+FROM python:$PYTHON_DOCKER_TAG as base
 MAINTAINER Evan Heidtmann <evan.heidtmann@gmail.com>
+RUN apt-get update && \
+        apt-get -y install \
+        libgeos-3.5.1 \
+        libgeos-c1v5 \
+        libogdi3.2 \
+        libproj12 \
+        libfreexl1 \
+        libspatialite7
+RUN wget --quiet https://bootstrap.pypa.io/get-pip.py && \
+    python3 get-pip.py
 
+FROM base AS builder
+ARG GDAL_VERSION=2.3.2
 RUN apt-get update && \
     apt-get -y install \
         wget \
@@ -17,36 +29,14 @@ RUN apt-get update && \
         libspatialite-dev \
         python3-dev \
         python3-numpy
-# RUN apt-get update && \
-#     apt-get -y install \
-#         wget \
-#         libcurl4-openssl-dev \
-#         build-essential \
-#         libpq-dev \
-#         ogdi-bin \
-#         libogdi3.2-dev \
-#         libjasper-runtime \
-#         libjasper-dev \
-#         libjasper1 \
-#         libgeos-dev \
-#         libproj-dev \
-#         libpoppler-dev \
-#         libsqlite3-dev \
-#         libspatialite-dev \
-#         python3 \
-#         python3-dev \
-#         python3-numpy
 
-RUN wget https://bootstrap.pypa.io/get-pip.py && \
-    python3 get-pip.py
-
-ARG GDAL_VERSION=2.3.1
-RUN wget http://download.osgeo.org/gdal/$GDAL_VERSION/gdal-${GDAL_VERSION}.tar.gz -O /tmp/gdal-${GDAL_VERSION}.tar.gz && \
+RUN wget --quiet http://download.osgeo.org/gdal/$GDAL_VERSION/gdal-${GDAL_VERSION}.tar.gz -O /tmp/gdal-${GDAL_VERSION}.tar.gz && \
     tar -x -f /tmp/gdal-${GDAL_VERSION}.tar.gz -C /tmp
 
 RUN cd /tmp/gdal-${GDAL_VERSION} && \
     ./configure \
-        --prefix=/usr \
+        --disable-static \
+        --prefix=/gdal/usr \
         --with-python \
         --with-geos \
         --with-sfcgal \
@@ -63,4 +53,5 @@ RUN cd /tmp/gdal-${GDAL_VERSION} && \
         --with-spatialite && \
     make -j $(nproc) && make install
 
-RUN rm /tmp/gdal-${GDAL_VERSION} -rf
+FROM base
+COPY --from=builder /gdal/usr/ /usr/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ This is a base image needed for many geographic extensions of Django.
 
 Run `./build.sh` to generate several versions of the image for different combinations of GDAL and Python.
 
-As of May 2019, this base image is used in:
+As of July 2019, this base image is used in:
+ - `authservice` -- https://github.com/RideReport/authservice
  - `djscoots` -- https://github.com/RideReport/djscoots
+ - `orchescooter` -- https://github.com/RideReport/authservice
  - `rideserver` -- https://github.com/RideReport/rideserver
+ - `scootpower` -- https://github.com/RideReport/scootpower

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
-#tags="3.4.9-stretch 3.5.6-stretch 3.6.7-stretch 3.7.3-stretch 2.7.16-stretch"
 tags="3.7.3-stretch"
-#tags="2.7.16-stretch"
-#gdals="2.3.1 2.3.2"
 gdals="2.3.2"
 
 set -ex


### PR DESCRIPTION
The two significant changes in this PR are 
1. Not building the static `gdal` library (which adds around 300MB all by itself)
2. Change the layering so the `gdal` build dependencies aren't part of the image.

I also removed some commented out code and updated some debian package names.