### PR TITLE
Install pcre in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG PYTHON_DOCKER_TAG=3.7.10-slim-buster
 FROM python:$PYTHON_DOCKER_TAG as base
 RUN apt-get update && \
 	mkdir -p /usr/share/man/man1 /usr/share/man/man7 && \
-        apt-get -y install --no-install-recommends postgresql-client=11+200+deb10u4 wget=1.20.1-1.1 libgdal20=2.4.0+dfsg-1+b1 build-essential=12.6 libpq-dev=11.10-0+deb10u1 mime-support=3.62 libssl1.1=1.1.1d-0+deb10u5 libzstd1=1.3.8+dfsg-3+deb10u1 openssl=1.1.1d-0+deb10u5 && \
+        apt-get -y install --no-install-recommends postgresql-client=11+200+deb10u4 wget=1.20.1-1.1 libgdal20=2.4.0+dfsg-1+b1 build-essential=12.6 libpq-dev=11.10-0+deb10u1 mime-support=3.62 libssl1.1=1.1.1d-0+deb10u5 libzstd1=1.3.8+dfsg-3+deb10u2 openssl=1.1.1d-0+deb10u5 libpcre3-dev=2:8.39-12 && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*
 # https://www.debian.org/releases/stable/amd64/release-notes/ch-information.en.html#openssl-defaults


### PR DESCRIPTION
We started getting a lot of new uwsgi errors when we deployed djscoots with an upgraded version of django. One of the errors we saw was:
```
!!! no internal routing support, rebuild with pcre support !!!
```

I think this means we need to install pcre before uwsgi, and this base image seemed like the best place to do this. It doesn't seem like this could have weird side effects on non-djscoots projects, but I would love for someone else to confirm that sounds reasonable!