### PR TITLE
Update pipenv version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN apt-get update && \
 # https://www.debian.org/releases/stable/amd64/release-notes/ch-information.en.html#openssl-defaults
 # TLDR: buster has tighter SSL requirements that AMZN hasn't met yet, allow a lower level:
 RUN sed -i -E -e 's/^CipherString\s+=\s+DEFAULT@SECLEVEL=2$/CipherString = DEFAULT/' /usr/lib/ssl/openssl.cnf
-RUN pip3 install pipenv==2018.11.26
+RUN pip3 install pipenv==2020.6.2

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Python with GDAL in a Docker image
 
 This is a base image needed for many geographic extensions of Django.
 
-Run `./build.sh` to generate several versions of the image for different combinations of GDAL and Python.
+Run `make manual-release` to generate a new Docker image and push it to ECR.
 
 As of July 2019, this base image is used in:
  - `authservice` -- https://github.com/RideReport/authservice


### PR DESCRIPTION
https://github.com/RideReport/tickets/issues/2403

In addition to bumping the pipenv version this also pulls up the ridereport common submodule and updates the readme.