### PR TITLE
Security updates

### DIFF
--- a/.release
+++ b/.release
@@ -1,2 +1,2 @@
-release=1.0.2
-tag=gdal-python-1.0.2
+release=2020_07_22_144542-8592646
+tag=gdal-python-2020_07_22_144542-8592646

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG PYTHON_DOCKER_TAG=3.7.4-slim-buster
 FROM python:$PYTHON_DOCKER_TAG as base
 RUN apt-get update && \
 	mkdir -p /usr/share/man/man1 /usr/share/man/man7 && \
-        apt-get -y install --no-install-recommends postgresql-client=11+200+deb10u2 wget=1.20.1-1.1 libgdal20=2.4.0+dfsg-1+b1 build-essential=12.6 libpq-dev=11.5-1+deb10u1 mime-support=3.62 && \
+        apt-get -y install --no-install-recommends postgresql-client=11+200+deb10u3 wget=1.20.1-1.1 libgdal20=2.4.0+dfsg-1+b1 build-essential=12.6 libpq-dev=11.7-0+deb10u1 mime-support=3.62 && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*
 # https://www.debian.org/releases/stable/amd64/release-notes/ch-information.en.html#openssl-defaults


### PR DESCRIPTION
https://github.com/RideReport/tickets/issues/2403

I noticed when trying to build a new version of the docker image with the new pipenv version from [this PR](https://github.com/RideReport/gdal-python-docker/pull/6) that we could no longer install the postgres client and libpq-dev packages due to security updates. This should change those packages to stable versions and I made sure that I can build a docker image with these references.