### PR TITLE
Upgrade to python 3.9

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,19 @@
+name: Build Docker Image
+on:
+  schedule:
+    - cron: '0 15 * * 1'
+  pull_request: {}
+  push:
+    branches:
+      - main
+jobs:
+  build-docker-image:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build Image
+        id: build
+        run: docker build . --file Dockerfile --tag baseimage
+      - name: Run Image
+        id: run
+        run: docker run --rm baseimage python --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_DOCKER_TAG=3.7.10-slim-buster
+ARG PYTHON_DOCKER_TAG=3.9.2-slim-buster
 FROM python:$PYTHON_DOCKER_TAG as base
 RUN apt-get update && \
 	mkdir -p /usr/share/man/man1 /usr/share/man/man7 && \


### PR DESCRIPTION
Shipping this won't upgrade any apps, just build an image that we can set as the `base image` for anything we want to upgrade.