### PR TITLE
Update hadolint config and Dockerfile

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
-- repo: local
+- repo: https://github.com/hadolint/hadolint
+  rev: v2.0.0
   hooks:
-    - id: hadolint
-      name: hadolint
-      description: Dockerfile linter
-      language: docker_image
-      types:
-        - dockerfile
-      pass_filenames: true
-      entry: hadolint/hadolint:latest hadolint
+  - id: hadolint-docker
+    args:
+    - --ignore
+    - DL3005
+    - --ignore
+    - DL3008
+    - "-"
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.3.0
+  rev: v3.4.0
   hooks:
   - id: check-yaml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 ARG PYTHON_DOCKER_TAG=3.9.2-slim-buster
 FROM python:$PYTHON_DOCKER_TAG as base
 RUN apt-get update && \
+	apt-get -y upgrade && \
 	mkdir -p /usr/share/man/man1 /usr/share/man/man7 && \
-        apt-get -y install --no-install-recommends postgresql-client=11+200+deb10u4 wget=1.20.1-1.1 libgdal20=2.4.0+dfsg-1+b1 build-essential=12.6 libpq-dev=11.10-0+deb10u1 mime-support=3.62 libssl1.1=1.1.1d-0+deb10u5 libzstd1=1.3.8+dfsg-3+deb10u2 openssl=1.1.1d-0+deb10u5 libpcre3-dev=2:8.39-12 && \
+        apt-get -y install --no-install-recommends postgresql-client wget libgdal20 build-essential libpq-dev mime-support libssl1.1 libzstd1 openssl && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*
 # https://www.debian.org/releases/stable/amd64/release-notes/ch-information.en.html#openssl-defaults


### PR DESCRIPTION
Update pre-commit. Make Dockerfile less painful to maintain by ignoring some hadolint rules.
